### PR TITLE
Use tsig parameter for dig, too.

### DIFF
--- a/lib/puppet/provider/dns_rr/nsupdate.rb
+++ b/lib/puppet/provider/dns_rr/nsupdate.rb
@@ -107,7 +107,12 @@ private
 
   def query
     unless @query
-      @query = dig("@#{server}", '+noall', '+answer', name, type, '-c', rrclass).lines.map do |line|
+      if keyed?
+        dig_text = dig("@#{server}", '+noall', '+answer', name, type, '-c', rrclass, '-y', tsig_param)
+      else
+        dig_text = dig("@#{server}", '+noall', '+answer', name, type, '-c', rrclass)
+      end
+      @query = dig_text.lines.map do |line|
         linearray = line.chomp.split(/\s+/, 5)
         {
           :name    => linearray[0],

--- a/lib/puppet/type/dns_rr.rb
+++ b/lib/puppet/type/dns_rr.rb
@@ -7,7 +7,7 @@ Puppet::Type.newtype(:dns_rr) do
     desc "Class/Type/Name for the resource record"
 
     validate do |value|
-      if (value =~ /^([A-Z]+)\/([A-Z]+)\/[a-zA-Z0-9.-]+$/)
+      if (value =~ /^([A-Z]+)\/([A-Z]+)\/[a-zA-Z0-9._-]+$/)
         rrclass = $1
         if ( !%w(IN CH HS).include? rrclass )
           raise ArgumentError, "Invalid resource record class: %s" % rrdata


### PR DESCRIPTION
Add the tsig_param when invoking dig using the -y command line option. This
allows dig and nsupdate to operate in the same view when views are matched by
tsig signature.
