### PR TITLE
add controllable order and support for match-recursive-only to views

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -7,11 +7,12 @@ define bind::view (
     $recursion                    = true,
     $recursion_match_clients      = 'any',
     $recursion_match_destinations = '',
+    $order                        = '10',
 ) {
     $confdir = $::bind::confdir
 
     concat::fragment { "bind-view-${name}":
-        order   => '10',
+        order   => $order,
         target  => "${::bind::confdir}/views.conf",
         content => template('bind/view.erb'),
     }

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -7,6 +7,7 @@ define bind::view (
     $recursion                    = true,
     $recursion_match_clients      = 'any',
     $recursion_match_destinations = '',
+    $recursion_match_only         = false,
     $order                        = '10',
 ) {
     $confdir = $::bind::confdir

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -15,6 +15,9 @@ view "<%= @name %>" {
 	};
 <%- end -%>
 	recursion <%= @recursion ? 'yes' : 'no' %>;
+<%- if @recursion_match_only -%>
+	match-recursive-only yes;
+<%- end -%>
 <%- if @recursion -%>
 <%-   if @recursion_match_clients and @recursion_match_clients != '' -%>
 	allow-recursion {


### PR DESCRIPTION
To achieve a setup I wanted to try (separate views for resolver and authoritative server role), I had to add two tweaks to the view class, since views used the same order value for all fragments (bind evaluates until first match, so order matters), and match-recursive-only was not supported.

P.S.: love your module, saved me a ton of time