### PR TITLE
Configure rndc correctly

### DIFF
--- a/lib/puppet/parser/functions/hmac_secret.rb
+++ b/lib/puppet/parser/functions/hmac_secret.rb
@@ -1,0 +1,9 @@
+# ex: syntax=ruby si sw=2 ts=2 et
+require 'securerandom'
+
+module Puppet::Parser::Functions
+  newfunction(:hmac_secret, :type => :rvalue) do |args|
+    bits = args[0].to_i
+    SecureRandom.base64(bits / 8)
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,17 @@ class bind (
         }
     }
 
+    if $rndc {
+        # rndc only supports HMAC-MD5
+        bind::key { 'rndc-key':
+            algorithm   => 'hmac-md5',
+            secret_bits => '512',
+            keydir      => $confdir,
+            keyfile     => 'rndc.key',
+            include     => false,
+        }
+    }
+
     file { [ $confdir, "${confdir}/zones" ]:
         ensure  => directory,
         mode    => '2755',
@@ -81,12 +92,6 @@ class bind (
         order   => '00',
         target  => "${confdir}/keys.conf",
         content => "# This file is managed by puppet - changes will be lost\n",
-    }
-
-    concat::fragment { 'named-keys-rndc':
-        order   => '99',
-        target  => "${confdir}/keys.conf",
-        content => "#include \"${confdir}/rndc.key\"\n",
     }
 
     concat::fragment { 'named-views-header':

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -1,28 +1,50 @@
 # ex: syntax=puppet si ts=4 sw=4 et
 
 define bind::key (
-    $secret,
-    $algorithm = 'hmac-sha256',
-    $owner     = 'root',
-    $group     = $bind::params::bind_group,
+    $secret      = undef,
+    $secret_bits = 256,
+    $algorithm   = 'hmac-sha256',
+    $owner       = 'root',
+    $group       = $bind::params::bind_group,
+    $keydir      = $::bind::keydir::keydir,
+    $keyfile     = undef,
+    $include     = true,
 ) {
-    $keydir = $::bind::keydir::keydir
 
-    file { "${keydir}/${name}":
+    # Generate a key of size $secret_bits if no $secret
+    $secret_actual = $secret ? {
+        undef   => hmac_secret($secret_bits),
+        default => $secret,
+    }
+
+    # Keep existing key if the module is generating a key
+    $replace = $secret ? {
+        undef   => false,
+        default => true,
+    }
+
+    # Use key name as key file name if none is supplied
+    $key_file_name = $keyfile ? {
+        undef   => $name,
+        default => $keyfile,
+    }
+
+    file { "${keydir}/${key_file_name}":
         ensure  => present,
         owner   => $owner,
         group   => $group,
         mode    => '0640',
+        replace => $replace,
         content => template('bind/key.conf.erb'),
     }
 
-    if (defined(Class['bind'])) {
-        Package['bind'] -> File["${keydir}/${name}"] ~> Service['bind']
+    if $include and defined(Class['bind']) {
+        Package['bind'] -> File["${keydir}/${key_file_name}"] ~> Service['bind']
 
         concat::fragment { "bind-key-${name}":
             order   => '10',
             target  => "${bind::confdir}/keys.conf",
-            content => "include \"${bind::confdir}/keys/${name}\";\n",
+            content => "include \"${keydir}/${key_file_name}\";\n",
         }
     }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,6 @@ class bind::params (
             "${::bind::confdir}/db.127",
             "${::bind::confdir}/db.255",
             "${::bind::confdir}/named.conf.default-zones",
-            "${::bind::confdir}/rndc.key",
             "${::bind::confdir}/zones.rfc1918",
         ]
     }

--- a/templates/key.conf.erb
+++ b/templates/key.conf.erb
@@ -1,5 +1,5 @@
 
 key <%= @name %> {
 	algorithm <%= @algorithm %>;
-	secret "<%= @secret %>";
+	secret "<%= @secret_actual %>";
 };

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -2,13 +2,6 @@
 include "<%= @confdir %>/acls.conf";
 include "<%= @confdir %>/keys.conf";
 include "<%= @confdir %>/views.conf";
-<%- if @rndc -%>
-
-include "<%= @confdir %>/rndc.key";
-controls {
-	inet 127.0.0.1 allow { localhost; } keys { rndc-key; };
-};
-<%- end -%>
 
 options {
 	directory "<%= @cachedir %>";


### PR DESCRIPTION
Rely on BIND's default behavior for configuring named's 'control' clause and rndc and just generate an rndc.key. In the case that the platform does this, it's a replace => false file resource anyway.