### PR TITLE
Add record type DS

### DIFF
--- a/lib/puppet/type/dns_rr.rb
+++ b/lib/puppet/type/dns_rr.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:dns_rr) do
           Util::Errors.fail "Invalid resource record class: %s" % rrdata
         end
         type = $2
-        if ( !%w(A AAAA CNAME NS MX SPF SRV NAPTR PTR TXT).include? type)
+        if ( !%w(A AAAA CNAME NS MX SPF SRV NAPTR PTR TXT DS).include? type)
           Util::Errors.fail "Invalid resource record type: %s" % type
         end
       else

--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -16,7 +16,7 @@ Puppet::Type.newtype(:resource_record) do
   newparam(:type) do
     desc 'The record type'
     isrequired
-    newvalues 'A', 'AAAA', 'CNAME', 'NS', 'MX', 'SPF', 'SRV', 'NAPTR', 'PTR', 'TXT'
+    newvalues 'A', 'AAAA', 'CNAME', 'NS', 'MX', 'SPF', 'SRV', 'NAPTR', 'PTR', 'TXT', 'DS'
   end
 
   newparam(:record) do


### PR DESCRIPTION
adds the record type DS (Delegation Signer), necessary for explicit management for delegating subdomains within DNSSEC-secured zones to establish a trust chain.

Example usage:
```
dns::record { 'sub.example.org-ds':
  record => 'sub.example.org',
  type   => 'DS',
  data   => ['64098 5 2 A27B47D72633FAF62BC4C7D7E9142081BF87F3048EBFDC77892E3B8D C35B32E9'],
  zone   => 'example.org',
}
```