### PR TITLE
make statistics channel available for use if configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class bind (
     $dnssec     = undef,
     $version    = undef,
     $rndc       = undef,
+    $statistics_port = undef,
 ) {
     include params
 

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -3,6 +3,12 @@ include "<%= @confdir %>/acls.conf";
 include "<%= @confdir %>/keys.conf";
 include "<%= @confdir %>/views.conf";
 
+<%- if @statistics_port -%>
+statistics-channels {
+    inet 127.0.0.1 port <%= @statistics_port %> allow { 127.0.0.1; };
+};
+<%- end -%>
+
 options {
 	directory "<%= @cachedir %>";
 <%- if @forwarders and @forwarders != '' -%>


### PR DESCRIPTION
A very simple implementation of enabling the statistics channel, specify `statistics_port` to enable the listener on localhost. I think the feature is available since Bind 9.5.

One could probably go much more sophisticated with specifying listener IPs and access policies, but I really didn't need the complexity.