### PR TITLE
CentOS / RedHat support

### DIFF
--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -1,0 +1,13 @@
+---
+bind::params::supported: true
+bind::params::bind_user: 'named'
+bind::params::bind_group: 'named'
+bind::params::bind_package: 'bind'
+bind::params::bind_service: 'named'
+bind::params::nsupdate_package: 'bind-utils'
+
+bind::confdir: '/etc/named'
+bind::cachedir: '/var/named/data'
+bind::rndc: true
+
+bind::updater::keydir: '/etc/named/keys'

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -7,7 +7,7 @@ bind::params::bind_service: 'named'
 bind::params::nsupdate_package: 'bind-utils'
 
 bind::confdir: '/etc/named'
-bind::cachedir: '/var/named/data'
+bind::cachedir: '/var/named'
 bind::rndc: true
 
 bind::updater::keydir: '/etc/named/keys'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,4 +25,7 @@ class bind::params (
             "${::bind::confdir}/zones.rfc1918",
         ]
     }
+    elsif $::osfamily == 'RedHat' {
+        $bind_files = ["/etc/named.root.key"]
+    }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,14 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [ "12.04", "14.04" ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [ "6" ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [ "6" ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
So here is the big one: I've added support for CentOS and thereby RedHat (compatible). I am running two named servers on CentOS 6 machines, so I can vouch for that version. I've had it running in a CentOS 7 test VM and I didn't get any errors, so it might work well there too. As to other Versions or other members of the RedHat osfamily (Scientific Linux etc) I can't really say much as I'm not running any systems with it.

I had to rework it quite a bit after the switch to hiera, but in the end it worked again.