### PR TITLE
Centos support

### DIFF
--- a/data/osfamily/Debian.yaml
+++ b/data/osfamily/Debian.yaml
@@ -5,7 +5,7 @@ bind::params::bind_group: 'bind'
 bind::params::bind_package: 'bind9'
 bind::params::bind_service: 'bind9'
 bind::params::nsupdate_package: 'dnsutils'
-
+bind::namedconf: '/etc/bind/named.conf'
 bind::confdir: '/etc/bind'
 bind::cachedir: '/var/cache/bind'
 bind::rndc: true

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -5,7 +5,7 @@ bind::params::bind_group: 'named'
 bind::params::bind_package: 'bind'
 bind::params::bind_service: 'named'
 bind::params::nsupdate_package: 'bind-utils'
-
+bind::namedonf: '/etc/named.conf'
 bind::confdir: '/etc/named'
 bind::cachedir: '/var/named'
 bind::rndc: true

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -5,7 +5,7 @@ bind::params::bind_group: 'named'
 bind::params::bind_package: 'bind'
 bind::params::bind_service: 'named'
 bind::params::nsupdate_package: 'bind-utils'
-bind::namedonf: '/etc/named.conf'
+bind::namedconf: '/etc/named.conf'
 bind::confdir: '/etc/named'
 bind::cachedir: '/var/named'
 bind::rndc: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 
 class bind (
     $confdir         = undef,
-    $namedonf        = undef,
+    $namedconf        = undef,
     $cachedir        = undef,
     $forwarders      = undef,
     $dnssec          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,7 @@
 
 class bind (
     $confdir         = undef,
+    $namedonf        = undef,
     $cachedir        = undef,
     $forwarders      = undef,
     $dnssec          = undef,
@@ -59,7 +60,7 @@ class bind (
         recurse => true,
     }
 
-    file { "${confdir}/named.conf":
+    file { "${namedconf}":
         content => template('bind/named.conf.erb'),
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class bind (
     $rndc            = undef,
     $statistics_port = undef,
 ) {
-    include params
+    include ::bind::params
 
     $auth_nxdomain = false
 

--- a/spec/classes/bind_spec.rb
+++ b/spec/classes/bind_spec.rb
@@ -11,8 +11,8 @@ describe 'bind' do
     })
   }
 
-  it { should contain_file('_CONFDIR_/named.conf').that_requires('Package[bind]') }
-  it { should contain_file('_CONFDIR_/named.conf').that_notifies('Service[bind]') }
+  it { should contain_file('_NAMEDCONF_').that_requires('Package[bind]') }
+  it { should contain_file('_NAMEDCONF_').that_notifies('Service[bind]') }
 
   it {
     should contain_service('bind').with({

--- a/spec/fixtures/hiera/common.yaml
+++ b/spec/fixtures/hiera/common.yaml
@@ -1,2 +1,3 @@
 ---
 bind::confdir: '_CONFDIR_'
+bind::namedconf: '_NAMEDCONF_'


### PR DESCRIPTION
Fix to specify the path to the main named.conf directly vs relative to the confdir as redhat derivatives use /etc/named.conf for the primary config file.

change the include for the params class to be fully qualified as currently it attempts to include ::params which fails the run.