### PR TITLE
Stub zones

### DIFF
--- a/files/db.empty
+++ b/files/db.empty
@@ -1,9 +1,9 @@
 $TTL	86400
 @	IN	SOA	localhost. root.localhost. (
 			      1		; Serial
-			 604800		; Refresh
-			  86400		; Retry
-			2419200		; Expire
-			  86400 )	; Negative Cache TTL
+			     60		; Refresh
+			     30		; Retry
+			    300		; Expire
+			     10 )	; Negative Cache TTL
 ;
 @	IN	NS	localhost.

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -38,15 +38,15 @@ define bind::zone (
         } else {
             $_source = 'puppet:///modules/bind/db.empty'
         }
-        unless $zone_type == 'stub' {
-            file { "${cachedir}/${name}":
-                ensure  => directory,
-                owner   => $bind::params::bind_user,
-                group   => $bind::params::bind_group,
-                mode    => '0755',
-                require => Package['bind'],
-            }
+        file { "${cachedir}/${name}":
+            ensure  => directory,
+            owner   => $bind::params::bind_user,
+            group   => $bind::params::bind_group,
+            mode    => '0755',
+            require => Package['bind'],
+        }
 
+        unless $zone_type == 'stub' {
             file { "${cachedir}/${name}/${_domain}":
                 ensure  => present,
                 owner   => $bind::params::bind_user,

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -28,7 +28,7 @@ define bind::zone (
         'master' => true,
         'slave'  => true,
         'hint'   => true,
-        'stub'   => true,
+        'stub'   => false,
         default  => false,
     }
 
@@ -79,7 +79,7 @@ define bind::zone (
             }
         }
     }
-
+    
     file { "${bind::confdir}/zones/${name}.conf":
         ensure  => present,
         owner   => 'root',

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -14,6 +14,7 @@ zone "<%= @_domain %>" {
 <%-   else -%>
 	file "<%= @cachedir %>/<%= @name %>/<%= @_domain %>";
 <%-   end -%>
+<%-   unless @zone_type == 'stub' -%>
 	notify <%= @ns_notify ? 'yes' : 'no' %>;
 <%-   if @also_notify and @also_notify != '' -%>
 	also-notify {

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -16,6 +16,7 @@ zone "<%= @_domain %>" {
 <%-   end -%>
 <%-   unless @zone_type == 'stub' -%>
 	notify <%= @ns_notify ? 'yes' : 'no' %>;
+<%-   end -%>
 <%-   if @also_notify and @also_notify != '' -%>
 	also-notify {
 <%-     Array(@also_notify).each do |server| -%>


### PR DESCRIPTION
Fix the zone template to prevent notify being added for stub zones as this creates an invalid zone.  Fix the zone defined type to prevent the zone file from being created  in the cache dir for stub zones.  With a stub zone you provide the master servers in the zone and bind will retrieve the NS records for that zone and create the zone file.  Creating the empty file causes the zone to be broken after the puppet run.  This is probably the case with a slave zone as well but don't have anything set up to test that right now.