### PR TITLE
Add zone includes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,10 @@ class bind (
         content => template('bind/named.conf.erb'),
     }
 
+    file { "${confdir}/include_zones.conf":
+        ensure => present,
+    }
+
     class { 'bind::keydir':
         keydir => "${confdir}/keys",
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,10 +64,6 @@ class bind (
         content => template('bind/named.conf.erb'),
     }
 
-    file { "${confdir}/include_zones.conf":
-        ensure => present,
-    }
-
     class { 'bind::keydir':
         keydir => "${confdir}/keys",
     }
@@ -80,6 +76,7 @@ class bind (
         "${confdir}/acls.conf",
         "${confdir}/keys.conf",
         "${confdir}/views.conf",
+        "${confdir}/include_zones.conf",
         ]:
         owner   => 'root',
         group   => $::bind::params::bind_group,
@@ -103,6 +100,12 @@ class bind (
     concat::fragment { 'named-views-header':
         order   => '00',
         target  => "${confdir}/views.conf",
+        content => "# This file is managed by puppet - changes will be lost\n",
+    }
+
+    concat::fragment { 'named-include_zones-header':
+        order   => '00',
+        target  => "${confdir}/include_zones.conf",
         content => "# This file is managed by puppet - changes will be lost\n",
     }
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -17,6 +17,9 @@ define bind::zone (
     $forward         = '',
     $source          = '',
 ) {
+
+    validate_re($ensure, ['^present$','^absent$'])
+
     $cachedir = $bind::cachedir
 
     if $domain == '' {
@@ -91,11 +94,11 @@ define bind::zone (
         require => Package['bind'],
     }
 
-    file_line { "${name}::include_line":
+    concat::fragment { "include_zones-${name}":
         ensure  => $ensure,
-        path    => "${bind::confdir}/include_zones.conf",
-        line    => "include \"${bind::confdir}/zones/${name}.conf\";",
-        notify  => Service['bind'],
-        require => File["${bind::confdir}/include_zones.conf"],
+        order   => '10',
+        target  => "${bind::confdir}/include_zones.conf",
+        content => template('bind/include_zones.erb'),
     }
+
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -2,6 +2,7 @@
 
 define bind::zone (
     $zone_type,
+    $ensure          = 'present',
     $domain          = '',
     $masters         = '',
     $transfer_source = '',
@@ -81,13 +82,22 @@ define bind::zone (
     }
 
     file { "${bind::confdir}/zones/${name}.conf":
-        ensure  => present,
+        ensure  => $ensure,
         owner   => 'root',
         group   => $bind::params::bind_group,
         mode    => '0644',
         content => template('bind/zone.conf.erb'),
         notify  => Service['bind'],
         require => Package['bind'],
+    }
+
+    ini_setting { "${name}::include":
+        ensure            => $ensure,
+        path              => "${bind::confdir}/zones.conf",
+        section           => '',
+        key_val_separator => ' ',
+        value             => "${bind::confdir}/zones/${name}.conf;",
+        notify            => Service['bind'],
     }
 
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -91,13 +91,11 @@ define bind::zone (
         require => Package['bind'],
     }
 
-    ini_setting { "${name}::include":
-        ensure            => $ensure,
-        path              => "${bind::confdir}/zones.conf",
-        section           => '',
-        key_val_separator => ' ',
-        value             => "${bind::confdir}/zones/${name}.conf;",
-        notify            => Service['bind'],
+    file_line { "${name}::include_line":
+        ensure  => $ensure,
+        path    => "${bind::confdir}/include_zones.conf",
+        line    => "include \"${bind::confdir}/zones/${name}.conf\";",
+        notify  => Service['bind'],
+        require => File["${bind::confdir}/include_zones.conf"],
     }
-
 }

--- a/templates/include_zones.erb
+++ b/templates/include_zones.erb
@@ -1,0 +1,1 @@
+include "<%= scope.lookupvar('::bind::confdir') %>/zones/<%=@name%>.conf";

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -2,6 +2,7 @@
 include "<%= @confdir %>/acls.conf";
 include "<%= @confdir %>/keys.conf";
 include "<%= @confdir %>/views.conf";
+include "<%= @confdir %>/include_zones.conf";
 <%- if @statistics_port -%>
 
 statistics-channels {


### PR DESCRIPTION
Add an include_zones.conf file that is included in the main named.conf that contains an include for each of the zone files created by the zone defined type.  This ensures that when a zone is added through the defined type that it will become active on the server.  This includes an 'ensure' parameter that can be set to absent to make sure the zone file and the include is removed.