### PR TITLE
Bind master lists support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class bind (
     concat { [
         "${confdir}/acls.conf",
         "${confdir}/keys.conf",
+        "${confdir}/masters.conf",
         "${confdir}/views.conf",
         ]:
         owner   => 'root',
@@ -92,6 +93,12 @@ class bind (
     concat::fragment { 'named-keys-header':
         order   => '00',
         target  => "${confdir}/keys.conf",
+        content => "# This file is managed by puppet - changes will be lost\n",
+    }
+
+    concat::fragment { 'named-masters-header':
+        order   => '00',
+        target  => "${confdir}/masters.conf",
         content => "# This file is managed by puppet - changes will be lost\n",
     }
 

--- a/manifests/masters.pp
+++ b/manifests/masters.pp
@@ -1,0 +1,13 @@
+# ex: syntax=puppet si ts=4 sw=4 et
+
+define bind::masters (
+    $addresses,
+) {
+
+    concat::fragment { "bind-masters-${name}":
+        order   => '10',
+        target  => "${bind::confdir}/masters.conf",
+        content => template('bind/masters.erb'),
+    }
+
+}

--- a/templates/masters.erb
+++ b/templates/masters.erb
@@ -1,0 +1,6 @@
+
+masters <%= @name %> {
+<%- Array(@addresses).each do |address| -%>
+	<%= address %>;
+<%- end -%>
+};

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -1,6 +1,7 @@
 # This file is managed by puppet - changes will be lost
 include "<%= @confdir %>/acls.conf";
 include "<%= @confdir %>/keys.conf";
+include "<%= @confdir %>/masters.conf";
 include "<%= @confdir %>/views.conf";
 <%- if @statistics_port -%>
 


### PR DESCRIPTION
Add a bind::masters type, which creates lists of master nameservers in /etc/bind/masters.conf. These lists can then be referenced in a slave zone definition, instead of specifying the master nameserver IP addresses directly in each slave zone.

 bind::masters { 'master-nameservers':
    addresses => ['192.168.1.2', 'fdc8:bf8b:e62c:abcd:1111:2222:3333:4444'],
 }

 bind::zone { 'example.com':
    zone_type       => 'slave',
    masters           => ['master-nameservers'],
    ns_notify         => false,
 }