### PR TITLE
Support custom keyfile paths

### DIFF
--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -42,6 +42,10 @@ Puppet::Type.newtype(:resource_record) do
     defaultto 'update'
   end
 
+  newparam(:keyfile) do
+    desc 'Keyfile used to update the record'
+  end
+
   newparam(:hmac) do
     desc 'The HMAC type of the update key'
     defaultto 'HMAC-SHA1'

--- a/lib/puppet_bind/provider/nsupdate.rb
+++ b/lib/puppet_bind/provider/nsupdate.rb
@@ -51,6 +51,8 @@ module PuppetBind
         file.close
         if keyed?
           nsupdate('-y', tsig_param, file.path)
+        elsif keyfile?
+          nsupdate('-k', kfile, file.path)
         else
           nsupdate(file.path)
         end
@@ -79,6 +81,14 @@ module PuppetBind
 
       def keyname
         resource[:keyname]
+      end
+
+      def kfile
+        resource[:keyfile]
+      end
+
+      def keyfile?
+        !kfile.nil?
       end
 
       def hmac


### PR DESCRIPTION
This makes it possible to use resource_record with "standalone" keyfiles by introducing a keyfile parameter. Behaviour is unchanged if it is not specified.