### PR TITLE
Allow response records from other sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ the same nameserver.
 `server` defaults to "localhost" and need not be specified. The value may be
 either a hostname or IP address.
 
+`query_section` indicates the section of the DNS response to check for existing
+record values. It must be one of `answer`, `authority`, or `additional`.
+Defaults to: `answer`
+
 `keyname` defaults to "update" and need not be specified. This parameter
 specifies the name of a TSIG key to be used to authenticate the update. The
 resource only uses a TSIG key if a `secret` is specified.

--- a/lib/puppet/type/dns_rr.rb
+++ b/lib/puppet/type/dns_rr.rb
@@ -51,6 +51,12 @@ Puppet::Type.newtype(:dns_rr) do
     defaultto 'localhost'
   end
 
+  newparam(:query_section) do
+    desc 'The DNS response section to check for existing record values'
+    defaultto 'answer'
+    newvalues 'answer', 'authority', 'additional'
+  end
+
   newparam(:keyname) do
     desc 'Keyname for the TSIG key used to update the record'
     defaultto 'update'

--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -37,6 +37,12 @@ Puppet::Type.newtype(:resource_record) do
     defaultto 'localhost'
   end
 
+  newparam(:query_section) do
+    desc 'The DNS response section to check for existing record values'
+    defaultto 'answer'
+    newvalues 'answer', 'authority', 'additional'
+  end
+
   newparam(:keyname) do
     desc 'Keyname for the TSIG key used to update the record'
     defaultto 'update'

--- a/lib/puppet_bind/provider/nsupdate.rb
+++ b/lib/puppet_bind/provider/nsupdate.rb
@@ -113,9 +113,9 @@ module PuppetBind
       def query
         unless @query
           if keyed?
-            dig_text = dig("@#{server}", '+noall', '+nosearch', "+#{query_section}", name, type, '-c', rrclass, '-y', tsig_param)
+            dig_text = dig("@#{server}", '+noall', '+nosearch', '+norecurse', "+#{query_section}", name, type, '-c', rrclass, '-y', tsig_param)
           else
-            dig_text = dig("@#{server}", '+noall', '+nosearch', "+#{query_section}", name, type, '-c', rrclass)
+            dig_text = dig("@#{server}", '+noall', '+nosearch', '+norecurse', "+#{query_section}", name, type, '-c', rrclass)
           end
           @query = dig_text.lines.map do |line|
             linearray = line.chomp.split(/\s+/, 5)

--- a/lib/puppet_bind/provider/nsupdate.rb
+++ b/lib/puppet_bind/provider/nsupdate.rb
@@ -86,6 +86,10 @@ module PuppetBind
         resource[:zone]
       end
 
+      def query_section
+        resource[:query_section]
+      end
+
       def keyname
         resource[:keyname]
       end
@@ -109,9 +113,9 @@ module PuppetBind
       def query
         unless @query
           if keyed?
-            dig_text = dig("@#{server}", '+noall', '+answer', name, type, '-c', rrclass, '-y', tsig_param)
+            dig_text = dig("@#{server}", '+noall', '+nosearch', "+#{query_section}", name, type, '-c', rrclass, '-y', tsig_param)
           else
-            dig_text = dig("@#{server}", '+noall', '+answer', name, type, '-c', rrclass)
+            dig_text = dig("@#{server}", '+noall', '+nosearch', "+#{query_section}", name, type, '-c', rrclass)
           end
           @query = dig_text.lines.map do |line|
             linearray = line.chomp.split(/\s+/, 5)


### PR DESCRIPTION
DNS queries for delegation records to poorly constructed zones won't have
answers, but they will have authority. Also, +nosearch