### PR TITLE
Improve error reporting

### DIFF
--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -24,7 +24,7 @@ Puppet::Type.newtype(:resource_record) do
     isrequired
 
     validate do |value|
-      Util::Errors.fail "Invalid value for record: #{value}" unless value =~ /^(\*\.)?([a-zA-Z0-9_-]+\.)*[a-zA-Z0-9_-]+$/
+      raise ArgumentError, "Invalid value for record: #{value}" unless value =~ /^(\*\.)?([a-zA-Z0-9_-]+\.)*[a-zA-Z0-9_-]+$/
     end
   end
 


### PR DESCRIPTION
I encountered a misleading error when passing invalid parameters to `resource_record`:
```
Error: Failed to apply catalog: Parameter record failed on Resource_record[xxxxx]: Validate method failed for class record: uninitialized constant Util at /path/to/my/manifest.pp:48
```
It seems that the recommended way to bubble up validation failures is `raise ArgumentError`: https://docs.puppetlabs.com/guides/custom_types.html#validation-and-munging