### PR TITLE
Misc fixes

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -30,8 +30,8 @@ define bind::zone (
         fail("transfer_source may only be provided for bind::zone resources with zone_type 'slave' or 'stub'")
     }
 
-    unless !($allow_update != '' and ! $dynamic) {
-        fail("allow_update may only be provided for bind::zone resources with dynamic set to true")
+    unless !($allow_updates != '' and ! $dynamic) {
+        fail("allow_updates may only be provided for bind::zone resources with dynamic set to true")
     }
 
     unless !($dnssec and ! $dynamic) {

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -21,8 +21,10 @@ options {
 	auth-nxdomain <%= @auth_nxdomain ? 'yes' : 'no' %>;
 	listen-on-v6 { any; };
 	dnssec-enable <%= @dnssec ? 'yes' : 'no' %>;
-	dnssec-validation <%= @dnssec ? 'yes' : 'no' %>;
-	dnssec-lookaside <%= @dnssec ? 'auto' : 'no' %>;
+<%- if @dnssec -%>
+	dnssec-validation yes;
+	dnssec-lookaside auto;
+<%- end -%>
 <%- if @version != '' -%>
 	version "<%= @version %>";
 <%- end -%>


### PR DESCRIPTION
`dnssec-lookaside no;` is not accepted by BIND combined with `dnssec-enable no;`:

```
named[11385]: loading configuration from '/etc/bind/named.conf'
named[11385]: /etc/bind/named.conf:15: dnssec-lookaside 'no': non-root not yet supported
named[11385]: /etc/bind/named.conf:15: dnssec-lookaside requires either 'auto' or a domain and trust anchor
```

Updated the named.conf template to skip all further DNSSEC related options when `$dnssec => false`.

Also noticed a mismatched variable name in `bind::zone` and fixed.