### PR TITLE
Add missing bind tools package and improve rspec tests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,12 @@ class bind (
         notify  => Service['bind'],
     }
 
+    package{'bind-tools':
+        ensure => latest,
+        name   => $::bind::params::nsupdate_package,
+        before => Package['bind'],
+    }
+
     package { 'bind':
         ensure => latest,
         name   => $::bind::params::bind_package,

--- a/spec/classes/bind_spec.rb
+++ b/spec/classes/bind_spec.rb
@@ -2,23 +2,66 @@
 require 'spec_helper'
 
 describe 'bind' do
-  let(:facts) { { :concat_basedir => '/wtf' } }
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :concat_basedir  => '/wtf',
+        :osfamily        => 'Debian',
+        :operatingsystem => 'Debian'
+      }
+    end
+    it {
+      should contain_package('bind-tools').with({
+        'ensure' => 'latest',
+        'name'   => 'dnsutils'
+      }).that_comes_before('Package[bind]')
+    }
+    it {
+      should contain_package('bind').with({
+        'ensure' => 'latest',
+        'name' => 'bind9'
+      })
+    }
 
-  it {
-    should contain_package('bind').with({
-      'ensure' => 'latest',
-      'name' => 'bind9'
-    })
-  }
+    it { should contain_file('_NAMEDCONF_').that_requires('Package[bind]') }
+    it { should contain_file('_NAMEDCONF_').that_notifies('Service[bind]') }
 
-  it { should contain_file('_NAMEDCONF_').that_requires('Package[bind]') }
-  it { should contain_file('_NAMEDCONF_').that_notifies('Service[bind]') }
+    it {
+      should contain_service('bind').with({
+        'ensure' => 'running',
+        'name' => 'bind9'
+      })
+    }
+  end
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :concat_basedir  => '/wtf',
+        :osfamily        => 'RedHat',
+        :operatingsystem => 'CentOS'
+      }
+    end
+    it {
+      should contain_package('bind-tools').with({
+        'ensure' => 'latest',
+        'name'   => 'bind-utils'
+      })
+    }
+    it {
+      should contain_package('bind').with({
+        'ensure' => 'latest',
+        'name'   => 'bind'
+      })
+    }
 
-  it {
-    should contain_service('bind').with({
-      'ensure' => 'running',
-      'name' => 'bind9'
-    })
-  }
+    it { should contain_file('_NAMEDCONF_').that_requires('Package[bind]') }
+    it { should contain_file('_NAMEDCONF_').that_notifies('Service[bind]') }
 
+    it {
+      should contain_service('bind').with({
+        'ensure' => 'running',
+        'name' => 'named'
+      })
+    }
+  end
 end


### PR DESCRIPTION
I found that the tools was also missing from Debian family. It is actually installed by default in everything but the minimal OS install which is why most would never see the issue. This commit addresses the missing package and adds rspec test for both Debian and RH family. 

Change-Id: I0b4680ce11fe604917fce654d68c2bec17c05438