### PR TITLE
Don't remove confdir files this remove standard files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@ class bind (
         }
     }
 
-    file { [ $confdir, "${confdir}/zones" ]:
+    file { [ "${confdir}/zones" ]:
         ensure  => directory,
         mode    => '2755',
         purge   => true,


### PR DESCRIPTION
If we remove confdir files all the Debian standard files are purged and bind doesn't work