### PR TITLE
Add the server directive to zone views

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -3,6 +3,7 @@
 define bind::view (
     $match_clients                = 'any',
     $match_destinations           = '',
+    $servers                      = {},
     $zones                        = [],
     $recursion                    = true,
     $recursion_match_clients      = 'any',

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -34,6 +34,15 @@ view "<%= @name %>" {
 	};
 <%-   end -%>
 <%- end -%>
+<%- if @server -%>
+<%-   @server.each_pair do |srv, srv_values| -%>
+	server <%= srv %> {
+<%-		Array(srv_values).each do |srv_value| -%>
+		<%= srv_value %>;
+<%-		end -%>
+	};
+<%-	  end -%>
+<%- end -%>
 <%- if scope.lookupvar('osfamily') == 'Debian' -%>
 	include "<%= @confdir %>/named.conf.default-zones";
 <%- end -%>


### PR DESCRIPTION
In certain circumstances, users of this module may want to add their own server directives to the zone view. An example is when a slave server connecting to or being notified from a particular master/masters require the use of a key and thus the configuration file needs to have the following:

```
server 10.0.0.1 {
    keys external-update;
}
```

This gives the ability to pass to the `bind::view` resource a new parameter:

```
bind::view { 'internet':
    recursion          => false,
    match_destinations => [ '198.0.2.2', ],
    zones              => [ 'example.net', 'example.com-external', ],
    servers            => {
         '10.0.0.1' => [ 'key external-update' ],
    },
}
```