### PR TITLE
Add support for unmanaged zone file

### DIFF
--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -9,9 +9,9 @@ zone "<%= @_domain %>" {
 <%-   else -%>
 	key-directory "<%= @cachedir %>/<%= @name %>";
 <%-   end -%>
-	file "<%= @cachedir %>/<%= @name %>/<%= @_domain %>.signed";
-<%- elsif %w(init managed allowed).include? @zone_file_mode -%>
-	file "<%= @cachedir %>/<%= @name %>/<%= @_domain %>";
+	file "<%= @_zoneFilePath %>.signed";
+<%- elsif %w(init managed allowed static).include? @zone_file_mode -%>
+	file "<%= @_zoneFilePath %>";
 <%- end -%>
 <%- if %w(master slave).include? @zone_type -%>
 	notify <%= @ns_notify ? 'yes' : 'no' %>;


### PR DESCRIPTION
Hi,

Your puppet module is realy usefull, unfortunently, it don't proper manage the creation of a recursive zone.

This pull request add another option `zonePath` on `bind::zone` class to proper manage static class

this is allow the definition of zone like :

        bind::zone { 'root':
                zone_type         => 'hint',
                dynamic           => false,
                domain            => ".",
                zonePath          => '/var/named/named.ca',
        }
