### PR TITLE
solve order issue with DDNS usage

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,4 +110,5 @@ class bind (
         hasrestart => true,
         hasstatus  => true,
     }
+	Service['bind'] ~> Resource_record<| |>
 }


### PR DESCRIPTION
When bind server is not running, you can be stuck to update DDNS entry, so I provides this small patch to ansure that all ddns entry will be checked and updated after the server is ensured running