### PR TITLE
Put confdir in the params class, and more..

### DIFF
--- a/data/osfamily/Debian.yaml
+++ b/data/osfamily/Debian.yaml
@@ -5,8 +5,8 @@ bind::params::bind_group: 'bind'
 bind::params::bind_package: 'bind9'
 bind::params::bind_service: 'bind9'
 bind::params::nsupdate_package: 'dnsutils'
+bind::params::confdir: '/etc/bind'
 bind::namedconf: '/etc/bind/named.conf'
-bind::confdir: '/etc/bind'
 bind::cachedir: '/var/cache/bind'
 bind::rndc: true
 

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -6,8 +6,8 @@ bind::params::bind_package: 'bind'
 bind::params::bind_service: 'named'
 bind::params::nsupdate_package: 'bind-utils'
 bind::params::managed_keys_directory: '/var/named/dynamic'
+bind::params::confdir: '/etc/named'
 bind::namedconf: '/etc/named.conf'
-bind::confdir: '/etc/named'
 bind::cachedir: '/var/named'
 bind::rndc: true
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 # ex: syntax=puppet si ts=4 sw=4 et
 
 class bind (
-    $confdir         = undef,
     $namedconf       = undef,
     $cachedir        = undef,
     $forwarders      = undef,
@@ -11,18 +10,13 @@ class bind (
     $statistics_port = undef,
     $random_device   = undef,
     $include_local   = undef,
-) {
-    include ::bind::params
-
-    # Re-scope members of bind::params for templating
-    $managed_keys_directory = $::bind::params::managed_keys_directory
-
+) inherits bind::params {
     $auth_nxdomain = false
 
     File {
         ensure  => present,
         owner   => 'root',
-        group   => $::bind::params::bind_group,
+        group   => $bind_group,
         mode    => '0644',
         require => Package['bind'],
         notify  => Service['bind'],
@@ -30,13 +24,13 @@ class bind (
 
     package{'bind-tools':
         ensure => latest,
-        name   => $::bind::params::nsupdate_package,
+        name   => $nsupdate_package,
         before => Package['bind'],
     }
 
     package { 'bind':
         ensure => latest,
-        name   => $::bind::params::bind_package,
+        name   => $bind_package,
     }
 
     if $dnssec {
@@ -79,7 +73,7 @@ class bind (
         "${confdir}/views.conf",
         ]:
         owner   => 'root',
-        group   => $::bind::params::bind_group,
+        group   => $bind_group,
         mode    => '0644',
         require => Package['bind'],
         notify  => Service['bind'],
@@ -105,7 +99,7 @@ class bind (
 
     service { 'bind':
         ensure     => running,
-        name       => $::bind::params::bind_service,
+        name       => $bind_service,
         enable     => true,
         hasrestart => true,
         hasstatus  => true,

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -10,6 +10,8 @@ define bind::key (
     $keyfile     = undef,
     $include     = true,
 ) {
+    include bind::params
+    $confdir = $::bind::params::confdir
 
     # Generate a key of size $secret_bits if no $secret
     $secret_actual = $secret ? {
@@ -43,7 +45,7 @@ define bind::key (
 
         concat::fragment { "bind-key-${name}":
             order   => '10',
-            target  => "${bind::confdir}/keys.conf",
+            target  => "${bind::params::confdir}/keys.conf",
             content => "include \"${keydir}/${key_file_name}\";\n",
         }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,8 @@ class bind::params (
     $bind_package,
     $bind_service,
     $nsupdate_package,
-    $managed_keys_directory = nil,
+    $managed_keys_directory = undef,
+    $confdir,
 ) {
     unless $supported {
         fail('Platform is not supported')

--- a/manifests/updater.pp
+++ b/manifests/updater.pp
@@ -2,13 +2,12 @@
 
 class bind::updater (
     $keydir = undef,
-) {
-    include params
+) inherits bind::params {
 
-    if $::bind::params::nsupdate_package {
+    if $nsupdate_package {
         package { 'nsupdate':
             ensure => present,
-            name   => $::bind::params::nsupdate_package,
+            name   => $nsupdate_package,
         }
     }
 

--- a/spec/fixtures/hiera/common.yaml
+++ b/spec/fixtures/hiera/common.yaml
@@ -1,3 +1,3 @@
 ---
-bind::confdir: '_CONFDIR_'
+bind::params::confdir: '_CONFDIR_'
 bind::namedconf: '_NAMEDCONF_'


### PR DESCRIPTION
Fix a bunch of warnings whne using the bind::updater class by moving confdir to
the params class. In order for this to work, the bind and bind::updater classes
both now inherit from params. Also, fix the default value for
managed_key_directory to something that's actually falsey.