### PR TITLE
Check for API support for autorequire

### DIFF
--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -7,9 +7,11 @@ Puppet::Type.newtype(:resource_record) do
   autorequire(:service) do
     reqs = []
     # Depend on the bind service if the record is local
-    reqs << 'bind' if Socket.ip_address_list.any? do |intf|
-      Resolv.getaddresses(self[:server]).any? do |addr|
-        intf.ip_address === addr
+    if Socket.respond_to? :ip_address_list
+      reqs << 'bind' if Socket.ip_address_list.any? do |intf|
+        Resolv.getaddresses(self[:server]).any? do |addr|
+          intf.ip_address === addr
+        end
       end
     end
     reqs

--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -7,11 +7,9 @@ Puppet::Type.newtype(:resource_record) do
   autorequire(:service) do
     reqs = []
     # Depend on the bind service if the record is local
-    if Socket.respond_to? :ip_address_list
-      reqs << 'bind' if Socket.ip_address_list.any? do |intf|
-        Resolv.getaddresses(self[:server]).any? do |addr|
-          intf.ip_address === addr
-        end
+    reqs << 'bind' if !Socket.respond_to? :ip_address_list or Socket.ip_address_list.any? do |intf|
+      Resolv.getaddresses(self[:server]).any? do |addr|
+        intf.ip_address === addr
       end
     end
     reqs


### PR DESCRIPTION
`Socket.ip_address_list` is a new addition to ruby 1.9. Maintain support for
ruby 1.8.7 by making the new autorequire feature of `resource_record`
conditional on the existence of the required API.