### PR TITLE
Redhat default zones

### DIFF
--- a/data/osfamily/Debian.yaml
+++ b/data/osfamily/Debian.yaml
@@ -8,5 +8,6 @@ bind::defaults::nsupdate_package: 'dnsutils'
 bind::defaults::confdir: '/etc/bind'
 bind::defaults::namedconf: '/etc/bind/named.conf'
 bind::defaults::cachedir: '/var/cache/bind'
+bind::defaults::default_zones_include: '/etc/bind/named.conf.default-zones'
 
 bind::updater::keydir: '/etc/bind/keys'

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -11,6 +11,6 @@ bind::defaults::namedconf: '/etc/named.conf'
 bind::defaults::cachedir: '/var/named'
 bind::defaults::default_zones_warning: true
 bind::defaults::default_zones_include: '/etc/named.default-zones.conf'
-bind::defaults::default_zones_source: 'puppet:///module/bind/RedHat/named.default-zones.conf'
+bind::defaults::default_zones_source: 'puppet:///modules/bind/RedHat/named.default-zones.conf'
 
 bind::updater::keydir: '/etc/named/keys'

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -10,5 +10,7 @@ bind::defaults::confdir: '/etc/named'
 bind::defaults::namedconf: '/etc/named.conf'
 bind::defaults::cachedir: '/var/named'
 bind::defaults::default_zones_warning: true
+bind::defaults::default_zones_include: '/etc/named.default-zones.conf'
+bind::defaults::default_zones_source: 'puppet:///module/bind/RedHat/named.default-zones.conf'
 
 bind::updater::keydir: '/etc/named/keys'

--- a/files/RedHat/named.default-zones.conf
+++ b/files/RedHat/named.default-zones.conf
@@ -1,0 +1,6 @@
+zone "." IN {
+	type hint;
+	file "named.ca";
+};
+
+include "/etc/named.rfc1912.zones";

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -13,6 +13,8 @@ class bind::defaults (
     $nsupdate_package       = undef,
     $managed_keys_directory = undef,
     $default_zones_warning  = undef,
+    $default_zones_include  = undef,
+    $default_zones_source   = undef,
 ) {
     unless is_bool($supported) {
         fail('Please ensure that the dependencies of the bind module are installed and working correctly')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,12 @@ class bind (
         content => template('bind/named.conf.erb'),
     }
 
+    if $default_zones_source {
+        file { $default_zones_include:
+            source => $default_zones_source,
+        }
+    }
+
     class { 'bind::keydir':
         keydir => "${confdir}/keys",
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,8 @@ class bind (
     $rndc                  = undef,
     $statistics_port       = undef,
     $auth_nxdomain         = false,
-    $include_local         = false,
     $include_default_zones = true,
+    $include_local         = false,
 ) inherits bind::defaults {
 
     File {
@@ -62,7 +62,7 @@ class bind (
         content => template('bind/named.conf.erb'),
     }
 
-    if $default_zones_source {
+    if $include_default_zones and $default_zones_source {
         file { $default_zones_include:
             source => $default_zones_source,
         }

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -13,6 +13,7 @@ define bind::view (
 ) {
     $confdir = $::bind::confdir
     $default_zones_include = $::bind::default_zones_include
+    $include_default_zones = $::bind::include_default_zones
 
     concat::fragment { "bind-view-${name}":
         order   => $order,

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -12,6 +12,7 @@ define bind::view (
     $order                        = '10',
 ) {
     $confdir = $::bind::confdir
+    $default_zones_include = $::bind::default_zones_include
 
     concat::fragment { "bind-view-${name}":
         order   => $order,

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -44,7 +44,7 @@ view "<%= @name %>" {
 	};
 <%-   end -%>
 <%- end -%>
-<%- if @default_zones_include -%>
+<%- if @include_default_zones and @default_zones_include -%>
 	include "<%= @default_zones_include %>";
 <%- end -%>
 

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -44,8 +44,8 @@ view "<%= @name %>" {
 	};
 <%-   end -%>
 <%- end -%>
-<%- if scope.lookupvar('osfamily') == 'Debian' -%>
-	include "<%= @confdir %>/named.conf.default-zones";
+<%- if @default_zones_include -%>
+	include "<%= @default_zones_include %>";
 <%- end -%>
 
 <%- Array(@zones).each do |zone| -%>


### PR DESCRIPTION
Add support for retention of default zone data and configuration on RedHat and RedHat-derived systems. The module already supports this on the Debian family.