### PR TITLE
Root zone naming

### DIFF
--- a/files/dnssec-init
+++ b/files/dnssec-init
@@ -8,11 +8,17 @@ RANDOM_DEVICE="$5"
 NSEC3_SALT="$6"
 PATH=/bin:/sbin:/usr/bin:/usr/sbin
 
+if [ "${DOMAIN}" == "." ]; then
+    ZONE_FILE=root
+else
+    ZONE_FILE="${DOMAIN}"
+fi
+
 dnssec-keygen -a RSASHA256 -b 1024 -r "${RANDOM_DEVICE}" -K "${KEY_DIRECTORY}" "${DOMAIN}"
 dnssec-keygen -a RSASHA256 -b 2048 -r "${RANDOM_DEVICE}" -f KSK -K "${KEY_DIRECTORY}" "${DOMAIN}"
 
 if [ $NSEC3_SALT != '' ]; then
-    dnssec-signzone -S -u -3 ${NSEC3_SALT} -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${DOMAIN}"
+    dnssec-signzone -S -u -3 ${NSEC3_SALT} -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${ZONE_FILE}"
 else
-    dnssec-signzone -S -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${DOMAIN}"
+    dnssec-signzone -S -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${ZONE_FILE}"
 fi

--- a/files/dnssec-init
+++ b/files/dnssec-init
@@ -6,13 +6,8 @@ DOMAIN="$3"
 KEY_DIRECTORY="${4:-${CACHEDIR}/${NAME}}"
 RANDOM_DEVICE="$5"
 NSEC3_SALT="$6"
+ZONE_FILE="$7"
 PATH=/bin:/sbin:/usr/bin:/usr/sbin
-
-if [ "${DOMAIN}" == "." ]; then
-    ZONE_FILE=root
-else
-    ZONE_FILE="${DOMAIN}"
-fi
 
 dnssec-keygen -a RSASHA256 -b 1024 -r "${RANDOM_DEVICE}" -K "${KEY_DIRECTORY}" "${DOMAIN}"
 dnssec-keygen -a RSASHA256 -b 2048 -r "${RANDOM_DEVICE}" -f KSK -K "${KEY_DIRECTORY}" "${DOMAIN}"

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -126,7 +126,8 @@ define bind::zone (
     if $dnssec {
         exec { "dnssec-keygen-${name}":
             command => "/usr/local/bin/dnssec-init '${cachedir}' '${name}'\
-                '${_domain}' '${key_directory}' '${random_device}' '${nsec3_salt}'",
+                '${_domain}' '${key_directory}' '${random_device}' '${nsec3_salt}'\
+                '${zone_file}'",
             cwd     => $cachedir,
             user    => $bind_user,
             creates => "${cachedir}/${name}/${zone_file}.signed",

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -9,9 +9,9 @@ zone "<%= @_domain %>" {
 <%-   else -%>
 	key-directory "<%= @cachedir %>/<%= @name %>";
 <%-   end -%>
-	file "<%= @cachedir %>/<%= @name %>/<%= @_domain %>.signed";
+	file "<%= @cachedir %>/<%= @name %>/<%= @zone_file %>.signed";
 <%- elsif %w(init managed allowed).include? @zone_file_mode -%>
-	file "<%= @cachedir %>/<%= @name %>/<%= @_domain %>";
+	file "<%= @cachedir %>/<%= @name %>/<%= @zone_file %>";
 <%- end -%>
 <%- if %w(master slave).include? @zone_type -%>
 	notify <%= @ns_notify ? 'yes' : 'no' %>;


### PR DESCRIPTION
Fixes a bug in declaring a root zone. `.` does not work as a filename.