### PR TITLE
support forwarding a zone to a dns server on port other than 53

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -18,6 +18,7 @@ define bind::zone (
     $forwarders      = '',
     $forward         = '',
     $source          = '',
+    $forwarders_port = 53,
 ) {
     # where there is a zone, there is a server
     include bind

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -67,7 +67,7 @@ zone "<%= @_domain %>" {
 <%- if @forwarders and @forwarders != '' -%>
 	forwarders {
 <%-   Array(@forwarders).each do |forwarder| -%>
-		<%= forwarder %>;
+		<%= forwarder %><%-if @forwarders_port != 53 -%> port <%= @forwarders_port %><%- end -%>;
 <%-   end -%>
 	};
 <%- end -%>


### PR DESCRIPTION
e.g. Consul DNS uses port 8600
https://www.consul.io/docs/guides/forwarding.html
```
zone "consul" IN {
  type forward;
  forward only;
  forwarders { 127.0.0.1 port 8600; };
};
```
This assumes that all the fowarders you are forwarding to are on the same port. If you are OK with the change but want it to support a parallel port array I might be able to figure that out.
