### PR TITLE
support use of Puppet 4 module data

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,9 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "OS family"
+    backend: yaml
+    path: "osfamily/%{facts.os.family}"
+  - name: "common"
+    backend: yaml

--- a/metadata.json
+++ b/metadata.json
@@ -30,5 +30,6 @@
     { "name": "puppetlabs/stdlib" },
     { "name": "puppetlabs/concat", "version_requirement": ">=1.0.0 <2.0.0" },
     { "name": "ripienaar/module_data", "version_requirement": ">=0.0.3" }
-  ]
+  ],
+  "data_provider": "hiera"
 }


### PR DESCRIPTION
I am running your module without module_data using the built-in support for module data that is in the recent puppet versions. I am assuming this change wouldn't harm anyone using an older version of puppet but I haven't confirmed that. 

https://docs.puppetlabs.com/puppet/latest/reference/lookup_quick_module.html