### PR TITLE
Add allow-empty-zones support.

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -9,6 +9,7 @@ define bind::view (
     $recursion_match_clients      = 'any',
     $recursion_match_destinations = '',
     $recursion_match_only         = false,
+    $empty_zones                  = '',
     $order                        = '10',
 ) {
     $confdir = $::bind::confdir

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -34,6 +34,9 @@ view "<%= @name %>" {
 	};
 <%-   end -%>
 <%- end -%>
+<%- if @empty_zones != '' -%>
+	empty-zones-enable <%= @empty_zones ? 'yes' : 'no' %>;
+<%- end -%>
 <%- if @servers and @servers.is_a?(Array) -%>
 <%-   @servers.each do |properties| -%>
 <%-     raise Puppet::Error, 'view servers must have an ip_addr key' unless properties.has_key?('ip_addr') -%>


### PR DESCRIPTION
See: https://deepthought.isc.org/article/AA-00800/0/Automatic-empty-zones-including-RFC-1918-prefixes.html

Defaults to unspecified, as Bind's behaviour differs depending on (minor!) version, and whether recursion is enabled on a view.

Conflicts:
	manifests/view.pp
	templates/view.erb

fixes #84 