### PR TITLE
Allow 'explicit' zone notification

### DIFF
--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -14,7 +14,11 @@ zone "<%= @_domain %>" {
 	file "<%= @cachedir %>/<%= @name %>/<%= @zone_file %>";
 <%- end -%>
 <%- if %w(master slave).include? @zone_type -%>
+	<%- if (@ns_notify == 'explicit') -%>
+	notify explicit;
+	<%- else -%>
 	notify <%= @ns_notify ? 'yes' : 'no' %>;
+	<%- end -%>
 <%- end -%>
 <%- if @also_notify and @also_notify != '' -%>
 	also-notify {


### PR DESCRIPTION
Allow the 'explicit' value of a zones notify config to be set as well as yes/no.