### PR TITLE
Add `allow-transfers` to views

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -9,6 +9,7 @@ define bind::view (
     $recursion_match_clients      = 'any',
     $recursion_match_destinations = '',
     $recursion_match_only         = false,
+    $allow_transfers              = '',
     $notify_source                = '',
     $also_notify                  = '',
     $empty_zones                  = '',

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -34,6 +34,13 @@ view "<%= @name %>" {
 	};
 <%-   end -%>
 <%- end -%>
+<%- if @allow_transfers and @allow_transfers != '' -%>
+	allow-transfer {
+<%-   Array(@allow_transfers).each do |allow_transfer| -%>
+		<%= allow_transfer %>;
+<%-   end -%>
+	};
+<%- end -%>
 <%- if @empty_zones != '' -%>
 	empty-zones-enable <%= @empty_zones ? 'yes' : 'no' %>;
 <%- end -%>


### PR DESCRIPTION
Views support an `allow-transfer` directive essentially identical to the one in
zones. Copy the code from `manifests/zone.pp` and `templates/zone.conf.erb` to
support it.

Fixes #89 