### PR TITLE
Use a relative path load on LoadError

### DIFF
--- a/lib/puppet/provider/dns_rr/nsupdate.rb
+++ b/lib/puppet/provider/dns_rr/nsupdate.rb
@@ -1,4 +1,10 @@
-require 'puppet_bind/provider/nsupdate'
+begin
+  require 'puppet_bind/provider/nsupdate'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppet_bind/provider/nsupdate')
+end
 
 Puppet::Type.type(:dns_rr).provide(:nsupdate) do
 

--- a/lib/puppet/provider/resource_record/nsupdate.rb
+++ b/lib/puppet/provider/resource_record/nsupdate.rb
@@ -1,4 +1,10 @@
-require 'puppet_bind/provider/nsupdate'
+begin
+  require 'puppet_bind/provider/nsupdate'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppet_bind/provider/nsupdate')
+end
 
 Puppet::Type.type(:resource_record).provide(:nsupdate) do
 


### PR DESCRIPTION
Some versions of Puppet suffer from a regression which prevents them from
successfully loading auxilliary code in the module's lib directory. See
https://tickets.puppetlabs.com/browse/SERVER-973

Fixes #80 