### PR TITLE
Allow master/slave zones to set forwarders

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -69,12 +69,12 @@ define bind::zone (
         fail("allow_notify may only be provided for bind::zone resources with zone_type 'slave' or 'stub'")
     }
 
-    unless !($forwarders != '' and $zone_type != 'forward') {
-        fail("forwarders may only be provided for bind::zone resources with zone_type 'forward'")
+    unless !($forwarders != '' and ! member(['master', 'slave', 'forward'], $zone_type)) {
+        fail("forwarders may only be provided for bind::zone resources with zone_type 'forward' or 'master' or 'slave'")
     }
 
-    unless !($forward != '' and $zone_type != 'forward') {
-        fail("forward may only be provided for bind::zone resources with zone_type 'forward'")
+    unless !($forward != '' and ! member(['master', 'slave', 'forward'], $zone_type)) {
+        fail("forward may only be provided for bind::zone resources with zone_type 'forward' or 'master' or 'slave'")
     }
 
     unless !($source != '' and ! member(['master', 'hint'], $zone_type)) {

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -73,8 +73,10 @@ zone "<%= @_domain %>" {
 <%- end -%>
 <%- if @forwarders and @forwarders != '' -%>
 	forwarders {
+<%- if @forwarders != 'none' -%>
 <%-   Array(@forwarders).each do |forwarder| -%>
 		<%= forwarder %><%-if @forwarders_port != 53 -%> port <%= @forwarders_port %><%- end -%>;
+<%-   end -%>
 <%-   end -%>
 	};
 <%- end -%>


### PR DESCRIPTION
Allow master and slave zones (as well as forward as is currently allowed) to set forward and forwarders options.

This is so that this (https://kb.isc.org/article/AA-00538/0/How-can-I-disable-global-forwarding-for-delegated-subdomains.html) use case works.

To create an empty `forwarders { }; `option pass `forwarders => 'none'` to the zone.