### PR TITLE
Implement a helper script for zone reloads

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,6 @@
 ---
 bind::defaults::supported: false
 bind::defaults::random_device: '/dev/random'
-bind::defaults::rndc: true
 
 bind::forwarders: ''
 bind::dnssec: true

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -25,4 +25,9 @@ define bind::view (
         target  => "${::bind::confdir}/views.conf",
         content => template('bind/view.erb'),
     }
+
+    concat::fragment { "bind-view-mappings-${name}":
+        target  => "${::bind::confdir}/view-mappings.txt",
+        content => template('bind/view-mappings.erb'),
+    }
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -115,7 +115,7 @@ define bind::zone (
 
         if $zone_file_mode == 'managed' {
             exec { "rndc reload ${_domain}":
-                command     => "/usr/sbin/rndc reload ${_domain}",
+                command     => "/usr/local/bin/rndc-helper reload ${name}",
                 user        => $bind_user,
                 refreshonly => true,
                 require     => Service['bind'],
@@ -161,4 +161,8 @@ define bind::zone (
         require => Package['bind'],
     }
 
+    concat::fragment { "bind-zone-mapping-${name}":
+        target  => "${::bind::confdir}/domain-mappings.txt",
+        content => "${name}:${_domain}\n",
+    }
 }

--- a/templates/rndc-helper.erb
+++ b/templates/rndc-helper.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+CONFDIR=<%= @confdir %>
+
+function param_lookup() {
+  local zone_name="${1}"
+  local domain="$(grep "^${zone_name}:" ${CONFDIR}/domain-mappings.txt | cut -f2 -d:)"
+  grep "^${zone_name}:" ${CONFDIR}/view-mappings.txt | cut -f2 -d: | sed -e "s/\(.*\)/${domain} IN \1/"
+}
+
+zone_name="${!#}"
+
+param_lookup "${zone_name}" | while read Z; do
+  if [ $# == 1 ]; then
+    echo $Z
+  else
+    sudo rndc "${@:1:$(($# - 1))}" $Z
+  fi
+done

--- a/templates/view-mappings.erb
+++ b/templates/view-mappings.erb
@@ -1,0 +1,3 @@
+<%- @zones.each do |zone| -%>
+<%= zone %>:<%= @name %>
+<%- end -%>


### PR DESCRIPTION
The `rndc` invocation in `bind::zone` needs to include class and view parameters when a zone is included in multiple views. Not an easy problem because the information isn't all available together during the puppet run.