### PR TITLE
Add local_options (fix #102)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class bind (
     $auth_nxdomain         = false,
     $include_default_zones = true,
     $include_local         = false,
+    $local_options         = {},
 ) inherits bind::defaults {
 
     File {

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -34,6 +34,11 @@ options {
 <%- if @version != '' -%>
 	version "<%= @version %>";
 <%- end -%>
+<%- if @local_options -%>
+		<%- @local_options.each do |key, val| -%>
+	<%= key %> <%= val %>;
+		<%- end -%>
+<% end -%>
 };
 <%- if @include_local -%>
 


### PR DESCRIPTION
Fix for #102. Allows (optional) arbitrary local options hash.

    class { 'bind':
      forwarders    => [ '8.8.8.8', ],
      dnssec        => false,
      filter_ipv6   => true,
      local_options => {
        'test_opt'  => 'potato',
        'other_opt' => 'fries',
      }
    }