### PR TITLE
Add parameter: include_custom

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class bind (
     $version               = '',
     $statistics_port       = undef,
     $auth_nxdomain         = false,
+    $include_custom        = undef,
     $include_default_zones = true,
     $include_local         = false,
 ) inherits bind::defaults {

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -2,6 +2,11 @@
 include "<%= @confdir %>/acls.conf";
 include "<%= @confdir %>/keys.conf";
 include "<%= @confdir %>/views.conf";
+<%- if @include_custom -%>
+<%-   Array(@include_custom).each do |inc| -%>
+include "<%= @confdir %>/<%= inc %>";
+<%-   end -%>
+<%- end -%>
 <%- if @statistics_port -%>
 
 statistics-channels {


### PR DESCRIPTION
Added a parameter that enables the inclusion of bind configs managed by a Puppet but outside the Bind module (f.i. in a profile).

E.g.:

```
file { '/etc/bind/managed_elsewhere.conf':
  ensure  => file,
  content => template(...),
} ~> Class['::bind']
```

result:

```
$ cat /etc/bind/named.conf                                                                                                                                                                                  # This file is managed by puppet - changes will be lost
include "/etc/bind/acls.conf";
include "/etc/bind/keys.conf";
include "/etc/bind/managed_elsewhere.conf";

options {
        directory "/var/cache/bind";
        forwarders {
                    ...
        };
};
```