### PR TITLE
fix template if forward and version are undef in init.pp

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -21,7 +21,7 @@ options {
 <%-   end -%>
 	};
 <%- end -%>
-<%- if @forward != '' -%>
+<%- if @forward and @forward != '' -%>
 	forward <%= @forward %>;
 <%- end -%>
 	auth-nxdomain <%= @auth_nxdomain ? 'yes' : 'no' %>;
@@ -34,7 +34,7 @@ options {
 	dnssec-validation yes;
 	dnssec-lookaside auto;
 <%- end -%>
-<%- if @version != '' -%>
+<%- if @version and @version != '' -%>
 	version "<%= @version %>";
 <%- end -%>
 };


### PR DESCRIPTION
When not defining a version or forward option (undef), and leaving it to undef in init.pp, starting named fails. I've added a condition in the if statement for version and forward to mitigate this.
