### PR TITLE
Update to use at least the 2.0.0 version of puppetlabs-concat

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,26 +84,9 @@ class bind (
         owner   => 'root',
         group   => $bind_group,
         mode    => '0644',
+        warn    => true,
         require => Package['bind'],
         notify  => Service['bind'],
-    }
-
-    concat::fragment { 'named-acls-header':
-        order   => '00',
-        target  => "${confdir}/acls.conf",
-        content => "# This file is managed by puppet - changes will be lost\n",
-    }
-
-    concat::fragment { 'named-keys-header':
-        order   => '00',
-        target  => "${confdir}/keys.conf",
-        content => "# This file is managed by puppet - changes will be lost\n",
-    }
-
-    concat::fragment { 'named-views-header':
-        order   => '00',
-        target  => "${confdir}/views.conf",
-        content => "# This file is managed by puppet - changes will be lost\n",
     }
 
     service { 'bind':

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib" },
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.0.0 <2.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=2.0.0" }
   ],
   "data_provider": "hiera"
 }


### PR DESCRIPTION
The newer version of the concat module seem to fix errors like:

The fragments directory is empty, cowardly refusing to make empty config files

Concat also has a parameter which will automatically put the "this file is managed by puppet" header in place.