### PR TITLE
Implement support for logging configuration

### DIFF
--- a/data/osfamily/Debian.yaml
+++ b/data/osfamily/Debian.yaml
@@ -8,6 +8,7 @@ bind::defaults::nsupdate_package: 'dnsutils'
 bind::defaults::confdir: '/etc/bind'
 bind::defaults::namedconf: '/etc/bind/named.conf'
 bind::defaults::cachedir: '/var/cache/bind'
+bind::defaults::logdir: '/var/log/bind'
 bind::defaults::default_zones_include: '/etc/bind/named.conf.default-zones'
 
 bind::updater::keydir: '/etc/bind/keys'

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -9,6 +9,7 @@ bind::defaults::managed_keys_directory: '/var/named/dynamic'
 bind::defaults::confdir: '/etc/named'
 bind::defaults::namedconf: '/etc/named.conf'
 bind::defaults::cachedir: '/var/named'
+bind::defaults::logdir: '/var/log/named'
 bind::defaults::default_zones_include: '/etc/named.default-zones.conf'
 bind::defaults::default_zones_source: 'puppet:///modules/bind/RedHat/named.default-zones.conf'
 

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -5,6 +5,7 @@ class bind::defaults (
     $confdir                = undef,
     $namedconf              = undef,
     $cachedir               = undef,
+    $logdir                 = undef,
     $random_device          = undef,
     $bind_user              = undef,
     $bind_group             = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class bind (
         "${confdir}/keys.conf",
         "${confdir}/views.conf",
         "${confdir}/servers.conf",
+        "${confdir}/logging.conf",
         "${confdir}/view-mappings.txt",
         "${confdir}/domain-mappings.txt",
         ]:
@@ -88,6 +89,18 @@ class bind (
         warn    => true,
         require => Package['bind'],
         notify  => Service['bind'],
+    }
+
+    concat::fragment { 'bind-logging-header':
+        order   => "00-header",
+        target  => "${confdir}/logging.conf",
+        content => "logging {\n";
+    }
+
+    concat::fragment { 'bind-logging-footer':
+        order   => "99-footer",
+        target  => "${confdir}/logging.conf",
+        content => "};\n";
     }
 
     service { 'bind':

--- a/manifests/logging/category.pp
+++ b/manifests/logging/category.pp
@@ -1,0 +1,11 @@
+# ex: syntax=puppet si ts=4 sw=4 et
+
+define bind::logging::category (
+	$channels
+) {
+    concat::fragment { "bind-logging-category-${name}":
+        order   => "60-${name}",
+        target  => "${::bind::confdir}/logging.conf",
+        content => inline_template("\tcategory <%= @name %> {\n<% Array(@channels).each { |c| %>\t\t<%= c %>;\n<% } %>\t};\n"),
+    }
+}

--- a/manifests/logging/channel.pp
+++ b/manifests/logging/channel.pp
@@ -1,0 +1,49 @@
+# ex: syntax=puppet si ts=4 sw=4 et
+
+define bind::logging::channel (
+    $destination     = 'file',
+    $file_path       = $::bind::defaults::logdir,
+    $file_name       = '',
+    $syslog_facility = '',
+    $severity        = '',
+    $print_category  = true,
+    $print_severity  = true,
+    $print_time      = true,
+) {
+    unless member(['file', 'syslog', 'stderr', 'null'], $destination) {
+        fail("Bind::logging::channel[${name}] has invalid destination: ${destionation}. Must be one of: file syslog stderr null")
+    }
+
+    if $destination == 'file' {
+        unless defined(File[$file_path]) {
+            file { $file_path:
+                ensure => directory,
+                owner  => $::bind::bind_user,
+                group  => $::bind::bind_group,
+                mode   => '0640',
+            }
+        }
+
+        if $file_name == '' {
+            fail("Bind::logging::channel[${name}] must specify file_name when using file destination")
+        }
+    }
+
+    if $destination == 'syslog' {
+        unless member(['AUTH', 'AUTHPRIV', 'CRON', 'DAEMON', 'FTP', 'KERN', 'LOCAL0',
+                'LOCAL1', 'LOCAL2', 'LOCAL3', 'LOCAL4', 'LOCAL5', 'LOCAL6', 'LOCAL7',
+                'LPR', 'MAIL', 'NEWS', 'SYSLOG', 'USER', 'UUCP'], $syslog_facility) {
+            file("Bind::logging::channell[${name}] has invalid syslog_facility: ${syslog_facility}.")
+        }
+    }
+
+    unless $severity == '' or member(['critical', 'error', 'warning', 'notice', 'info', 'debug', 'dynamic'], $severity) {
+        fail("Bind::logging::channel[${name}] has invalid severity: ${severity}")
+    }
+
+    concat::fragment { "bind-logging-channel-${name}":
+        order   => "40-${name}",
+        target  => "${::bind::confdir}/logging.conf",
+        content => template('bind/logging_channel.erb'),
+    }
+}

--- a/templates/logging_channel.erb
+++ b/templates/logging_channel.erb
@@ -1,0 +1,18 @@
+	channel <%= @name %> {
+<%- case @destination -%>
+<%-   when "file" -%>
+		file "<%= @file_path %>/<%= @file_name %>";
+<%-   when "syslog" -%>
+		syslog <%= @syslog_facility %>;
+<%-   when "stderr" -%>
+		stderr;
+<%-   when "null" -%>
+		null;
+<%- end -%>
+<%- if @severity and @severity != '' -%>
+		severity <%= @severity %>;
+<%- end -%>
+		print-category <%= @print_category ? 'yes' : 'no' %>;
+		print-severity <%= @print_severity ? 'yes' : 'no' %>;
+		print-time <%= @print_time ? 'yes' : 'no' %>;
+	};

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -1,4 +1,5 @@
 # This file is managed by puppet - changes will be lost
+include "<%= @confdir %>/logging.conf";
 include "<%= @confdir %>/acls.conf";
 include "<%= @confdir %>/keys.conf";
 include "<%= @confdir %>/views.conf";


### PR DESCRIPTION
Adds `bind::logging::channel` and `bind::logging::category` defines in order to
support logging configuration.