### PR TITLE
Additional parameters tkey-*

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,17 @@
 # ex: syntax=puppet si ts=4 sw=4 et
 
 class bind (
-    $forwarders            = undef,
-    $forward               = undef,
-    $dnssec                = undef,
-    $filter_ipv6           = undef,
-    $version               = undef,
-    $statistics_port       = undef,
-    $auth_nxdomain         = undef,
-    $include_default_zones = true,
-    $include_local         = false,
+    $forwarders             = undef,
+    $forward                = undef,
+    $dnssec                 = undef,
+    $filter_ipv6            = undef,
+    $version                = undef,
+    $statistics_port        = undef,
+    $auth_nxdomain          = undef,
+    $include_default_zones  = true,
+    $include_local          = false,
+    $tkey_gssapi_credential = undef,
+    $tkey_domain            = undef,
 ) inherits bind::defaults {
 
     File {

--- a/spec/classes/bind_spec.rb
+++ b/spec/classes/bind_spec.rb
@@ -74,10 +74,29 @@ describe 'bind' do
         it { is_expected.to contain_file(expected_named_conf).that_requires('Package[bind]') }
         it { is_expected.to contain_file(expected_named_conf).that_notifies('Service[bind]') }
         it do
+          is_expected.to contain_file(expected_named_conf)
+            .with_content(/^options {$/)
+            .without_content(/^\s+tkey-gssapi-credential/)
+        end
+        it do
           is_expected.to contain_service('bind').with({
             ensure: 'running',
             name: expected_bind_service
           })
+        end
+      end
+      context 'with tkey-* parameters' do
+        let(:params) do
+          {
+            tkey_gssapi_credential: 'DNS/ds01.foobar.com',
+            tkey_domain: 'foobar.com'
+          }
+        end
+        it do
+          is_expected.to contain_file(expected_named_conf)
+            .with_content(/^options {$/)
+            .with_content(%r{^\s+tkey-gssapi-credential "DNS/ds01.foobar.com";$})
+            .with_content(%r{^\s+tkey-domain "foobar.com";$})
         end
       end
     end

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -42,6 +42,12 @@ options {
 <%- if @version != '' -%>
 	version "<%= @version %>";
 <%- end -%>
+<%- if @tkey_gssapi_credential -%>
+        tkey-gssapi-credential "<%= @tkey_gssapi_credential %>";
+<%- end -%>
+<%- if @tkey_domain -%>
+        tkey-domain "<%= @tkey_domain %>";
+<%- end -%>
 };
 <%- if @include_local -%>
 


### PR DESCRIPTION
As suggested by @inkblot in #126, here are 2 new parameters : `tkey-gssapi-credential` and `tkey-domain` that defaults to `undef` so previous behaviour is respected.

Regards,