### PR TITLE
Allow Zone file to be created from a template

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -103,7 +103,7 @@ define bind::zone (
         }
 
         if member(['init', 'managed'], $zone_file_mode) {
-            if ! is_empty($content) {
+            if ! empty($content) {
                 file { "${cachedir}/${name}/${zone_file}":
                   ensure  => present,
                   owner   => $bind_user,

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -19,6 +19,7 @@ define bind::zone (
     $forwarders      = '',
     $forward         = '',
     $source          = '',
+    $content         = '',
     $forwarders_port = 53,
 ) {
     # where there is a zone, there is a server
@@ -102,14 +103,26 @@ define bind::zone (
         }
 
         if member(['init', 'managed'], $zone_file_mode) {
-            file { "${cachedir}/${name}/${zone_file}":
-                ensure  => present,
-                owner   => $bind_user,
-                group   => $bind_group,
-                mode    => '0644',
-                replace => ($zone_file_mode == 'managed'),
-                source  => pick($source, 'puppet:///modules/bind/db.empty'),
-                audit   => [ content ],
+            if ! is_empty($content) {
+                file { "${cachedir}/${name}/${zone_file}":
+                  ensure  => present,
+                  owner   => $bind_user,
+                  group   => $bind_group,
+                  mode    => '0644',
+                  replace => ($zone_file_mode == 'managed'),
+                  content => $content,
+                  audit   => [ content ],
+                }
+            } else {
+                file { "${cachedir}/${name}/${zone_file}":
+                    ensure  => present,
+                    owner   => $bind_user,
+                    group   => $bind_group,
+                    mode    => '0644',
+                    replace => ($zone_file_mode == 'managed'),
+                    source  => pick($source, 'puppet:///modules/bind/db.empty'),
+                    audit   => [ content ],
+                }
             }
         }
 


### PR DESCRIPTION
Follow up from #101 to allow for putting in the file as content. If the $content parameter is non-empty use it as first preference.