### PR TITLE
add quotes to variables to fix "!=: unary operator expected"

### DIFF
--- a/files/dnssec-init
+++ b/files/dnssec-init
@@ -12,8 +12,8 @@ PATH=/bin:/sbin:/usr/bin:/usr/sbin
 dnssec-keygen -a RSASHA256 -b 1024 -r "${RANDOM_DEVICE}" -K "${KEY_DIRECTORY}" "${DOMAIN}"
 dnssec-keygen -a RSASHA256 -b 2048 -r "${RANDOM_DEVICE}" -f KSK -K "${KEY_DIRECTORY}" "${DOMAIN}"
 
-if [ $NSEC3_SALT != '' ]; then
-    dnssec-signzone -S -u -3 ${NSEC3_SALT} -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${ZONE_FILE}"
+if [ "$NSEC3_SALT" != '' ]; then
+    dnssec-signzone -S -u -3 "${NSEC3_SALT}" -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${ZONE_FILE}"
 else
     dnssec-signzone -S -d "${CACHEDIR}" -K "${KEY_DIRECTORY}" -o "${DOMAIN}" "${CACHEDIR}/${NAME}/${ZONE_FILE}"
 fi


### PR DESCRIPTION
Running dnssec-init manually gives an error:

/usr/local/bin/dnssec-init: line 15: [: !=: unary operator expected

It still completes successfully but looks a bit ugly.