### PR TITLE
don't add print-* logging options if destination is null

### DIFF
--- a/templates/logging_channel.erb
+++ b/templates/logging_channel.erb
@@ -12,7 +12,9 @@
 <%- if @severity and @severity != '' -%>
 		severity <%= @severity %>;
 <%- end -%>
+<%- if @destination != 'null' -%>
 		print-category <%= @print_category ? 'yes' : 'no' %>;
 		print-severity <%= @print_severity ? 'yes' : 'no' %>;
 		print-time <%= @print_time ? 'yes' : 'no' %>;
+<%- end -%>
 	};


### PR DESCRIPTION
`print-category`, `print-severity` and `print-time` options are not needed if the channel logging destination is set to `null`.