### PR TITLE
Allow setting check_names (for MS dns slave compatibility.)

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -20,6 +20,7 @@ define bind::zone (
     $forward         = '',
     $source          = '',
     $forwarders_port = 53,
+    $check_names     = true,
 ) {
     # where there is a zone, there is a server
     include ::bind

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -20,6 +20,9 @@ zone "<%= @_domain %>" {
 	notify <%= @ns_notify ? 'yes' : 'no' %>;
 <%-   end
     end -%>
+<%-   if !@check_names -%>
+       check-names ignore;
+<%-     end -%>
 <%- if @also_notify and @also_notify != '' -%>
 	also-notify {
 <%-   Array(@also_notify).each do |server| -%>


### PR DESCRIPTION
This change is required to allow bind to function as a microsoft server dns slave.

By default this change sets check_names to true, which is a no-op.  If explicitly set to false, it adds an entry to the zone file disabling check_names.  This change is only required for nonstandard formatted dns, such as what microsoft dns provides.