### PR TITLE
Add support for CAA records

### DIFF
--- a/lib/puppet/type/dns_rr.rb
+++ b/lib/puppet/type/dns_rr.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:dns_rr) do
           Util::Errors.fail "Invalid resource record class: %s" % rrdata
         end
         type = $2
-        if ( !%w(A AAAA CNAME NS MX SPF SRV NAPTR PTR TXT DS).include? type)
+        if ( !%w(A AAAA CAA CNAME NS MX SPF SRV NAPTR PTR TXT DS).include? type)
           Util::Errors.fail "Invalid resource record type: %s" % type
         end
       else

--- a/lib/puppet/type/resource_record.rb
+++ b/lib/puppet/type/resource_record.rb
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:resource_record) do
   newparam(:type) do
     desc 'The record type'
     isrequired
-    newvalues 'A', 'AAAA', 'CNAME', 'NS', 'MX', 'SPF', 'SRV', 'NAPTR', 'PTR', 'TXT', 'DS', 'TLSA', 'SSHFP'
+    newvalues 'A', 'AAAA', 'CAA', 'CNAME', 'NS', 'MX', 'SPF', 'SRV', 'NAPTR', 'PTR', 'TXT', 'DS', 'TLSA', 'SSHFP'
   end
 
   newparam(:record) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class bind (
     $forwarders                           = undef,
     $forward                              = undef,
     $dnssec                               = undef,
+    $dnssec_random_device                 = $::bind::defaults::random_device,
     $filter_ipv6                          = undef,
     $version                              = undef,
     $statistics_port                      = undef,

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -26,7 +26,7 @@ define bind::zone (
 
     # Pull some platform defaults and `bind` class parameters into the local scope
     $cachedir = $::bind::defaults::cachedir
-    $random_device = $::bind::defaults::random_device
+    $random_device = $::bind::dnssec_random_device
     $bind_user = $::bind::defaults::bind_user
     $bind_group = $::bind::defaults::bind_group
     $include_default_zones = $::bind::include_default_zones


### PR DESCRIPTION
CAA is a type of DNS record that allows site owners to specify which Certificate Authorities (CAs) are allowed to issue certificates containing their domain names. It was standardized in 2013 by RFC 6844 to allow a CA “reduce the risk of unintended certificate mis-issue.” By default, every public CA is allowed to issue certificates for any domain name in the public DNS, provided they validate control of that domain name. That means that if there’s a bug in any one of the many public CAs’ validation processes, every domain name is potentially affected. CAA provides a way for domain holders to reduce that risk.