### PR TITLE
Set dnssec-validation to auto so default trust anchors are used.

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -33,7 +33,7 @@ options {
 	filter-aaaa-on-v4 yes;
 <%- end -%>
 <%- if @dnssec -%>
-	dnssec-validation yes;
+	dnssec-validation auto;
 	dnssec-lookaside auto;
 <%-   if @isc_bind_keys -%>
         bindkeys-file "<%= @isc_bind_keys %>";


### PR DESCRIPTION
When dnssec-validation is set to yes, trust anchors must manually be
configured with either the trusted-keys or managed-keys directives.

When set to auto, bind will use either its compiled-in trust anchors or
those specified in the bind.keys file, if found.