### PR TITLE
Add support for unmanaged zone contents for externally-managed zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ bind::zone { 'example.com':
 }
 ```
 
+A master zone for which the zone contents are managed by an external tool (this module just ensures the zone exists
+and is served). Use of `resource_records` for an unmanaged zone is not supported.
+
+```
+bind::zone { 'example.com':
+    zone_type       => 'master',
+    manage_contents => false,
+}
+```
+
 A slave zone which allows notifications from servers matched by IP:
 
 ```

--- a/templates/zone.conf.erb
+++ b/templates/zone.conf.erb
@@ -10,7 +10,7 @@ zone "<%= @_domain %>" {
 	key-directory "<%= @cachedir %>/<%= @name %>";
 <%-   end -%>
 	file "<%= @cachedir %>/<%= @name %>/<%= @zone_file %>.signed";
-<%- elsif %w(init managed allowed).include? @zone_file_mode -%>
+<%- elsif %w(init managed unmanaged allowed).include? @zone_file_mode -%>
 	file "<%= @cachedir %>/<%= @name %>/<%= @zone_file %>";
 <%- end -%>
 <%- if %w(master slave).include? @zone_type


### PR DESCRIPTION
Adds `bind::zone::manage_contents` parameter which defaults to true. When set to false, the content of the zone file is not managed by puppet. This allows the module to co-exist with external tooling which manages the zone file contents, while still using this module to manage configuration of the zone. When manage_zone is set false for non-master zones, zone files are no longer removed from disk where this module thinks them not relevant.

Readme is updated with a usage example.