### PR TITLE
Remove deprecated option dnssec-lookaside as DLV was disabled

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -34,7 +34,6 @@ options {
 <%- end -%>
 <%- if @dnssec -%>
 	dnssec-validation yes;
-	dnssec-lookaside auto;
 <%-   if @isc_bind_keys -%>
         bindkeys-file "<%= @isc_bind_keys %>";
 <%-   end -%>


### PR DESCRIPTION
### Problem
named configured by inkblot-bind reports a warning on configuration check:
```
$ named-checkconf -j -z
/etc/bind/named.conf:14: dnssec-lookaside 'auto' is no longer supported
```

### Environment
```
mod 'inkblot-bind', '7.4.0'
```

### Solution
Remove deprecated named option dnssec-lookaside from config template as ISC's DLV was decommissioned on 30.09.2017:
* https://bind9.readthedocs.io/en/latest/reference.html#options-statement-definition-and-usage -- dnssec-lookaside
* https://www.isc.org/blogs/dlv/