### PR TITLE
Update to support bind version v9.16 and above.

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -28,7 +28,6 @@ options {
 <%- end -%>
 	auth-nxdomain <%= @auth_nxdomain ? 'yes' : 'no' %>;
 	listen-on-v6 { any; };
-	dnssec-enable <%= @dnssec ? 'yes' : 'no' %>;
 <%- if @filter_ipv6 -%>
 	filter-aaaa-on-v4 yes;
 <%- end -%>
@@ -38,6 +37,8 @@ options {
 <%-   if @isc_bind_keys -%>
         bindkeys-file "<%= @isc_bind_keys %>";
 <%-   end -%>
+<%- else - %>
+	dnssec-validation no;
 <%- end -%>
 <%- if @version != '' -%>
 	version "<%= @version %>";


### PR DESCRIPTION
dnssec-enable option has been obsoleted and no longer has any effect in bind v9.16

dnssec-validation is set to 'no' if @dnssec is false